### PR TITLE
fix fprint to more intuitive and generic usage

### DIFF
--- a/demo.c
+++ b/demo.c
@@ -18,7 +18,7 @@ int main() {
 	// char/byte are handled with extra love
 	unsigned char byte = 222;
 	char ch = 'A';
-	print(byte, ch)
+	print(byte, ch);
 
 	// you can setup your own colors
 	// arguments are: (normal, number, string, hex, fractional)
@@ -29,5 +29,5 @@ int main() {
 	__print_enable_color = 0;
 
 	// printing to fd is possible with fprintf
-	fprint(stderr, "Warning:", 42)
+	fprint(stderr, "Warning:", 42);
 }

--- a/print.h
+++ b/print.h
@@ -164,12 +164,12 @@ void __print_func (FILE *fd, int count, unsigned short types[], ...) {
 
 #define __print_types(a...) __print_types_int(a, (void)0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
 
-#define fprint(fd, a...)({ \
+#define fprint(fd, a...) do { \
 	int count = __print_count(a); \
 	unsigned short stack[count], *_p = stack + count; \
 	__print_types(a); \
 	__print_func(fd, count, _p, a); \
-});
+} while(0)
 
 #define print(a...) fprint(stdout, a)
 

--- a/print.h
+++ b/print.h
@@ -164,12 +164,12 @@ void __print_func (FILE *fd, int count, unsigned short types[], ...) {
 
 #define __print_types(a...) __print_types_int(a, (void)0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
 
-#define fprint(fd, a...) do { \
+#define fprint(fd, a...) ({ \
 	int count = __print_count(a); \
 	unsigned short stack[count], *_p = stack + count; \
 	__print_types(a); \
 	__print_func(fd, count, _p, a); \
-} while(0)
+})
 
 #define print(a...) fprint(stdout, a)
 


### PR DESCRIPTION
The design of `fprint` could force the user to write code that is not intuitive. They may have to ignore the semicolon after `fprint` function. For example:

```cpp
if(1)
    print("True");
else
    print("False");
```
The above code couldn't work, and that's because a semicolon is put at the end of `fprint`. So the compiler would say:
```
error: ‘else’ without a previous ‘if’
```

We can fix this by removing the last semicolon in `fprint` macro.  However, considering that the statement expressions `({...})` is non-standard C, so it could become the limitation for "generic" usage. Also, since we don't actually assign `fprint` to others(because `__print_func` return void type), I think we don't need to use statement expressions as well.

Note that the other solution could be to write `fprint` as a function directly.

