### PR TITLE
print.h,makefile: use switch..case and various other small changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,9 @@ print.3: print.3.ronn
 install: print.3
 	cp print.h $(DESTDIR)$(PREFIX)/include/
 	cp print.3 $(DESTDIR)$(PREFIX)/share/man/man3/
+uninstall:
+	rm -f $(DESKTOP)$(PREFIX)/include/print.h
+	rm -f $(DESKTOP)$(PREFIX)/share/man/man3/print.3
+clean:
+	rm -f demo
 

--- a/print.h
+++ b/print.h
@@ -1,6 +1,7 @@
 #ifndef PRINT_H
 #define PRINT_H
 
+#include <stdbool.h>
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -142,6 +143,11 @@ static void __print_func (FILE *fd, int count, unsigned short types[], ...) {
 			__print_array(fd, char*, "\"%s\"", __print_color_string);
 			break;
 		}
+		case 16: {
+		        c = va_arg(v, int);
+			fprintf(fd, c ? "\x1b[38;5;2mtrue": "\x1b[38;5;1mfalse");
+			break;
+		}
 		default:
 			fprintf(fd, "print: unsupported type (of size %i)\n", size);
 			break;
@@ -170,9 +176,10 @@ static void __print_func (FILE *fd, int count, unsigned short types[], ...) {
 	__builtin_choose_expr(__print_is_type(a, short[]), 13, \
 	__builtin_choose_expr(__print_is_type(a, unsigned short[]), 14, \
 	__builtin_choose_expr(__print_is_type(a, char*[]), 15, \
+	__builtin_choose_expr(__print_is_type(a, bool), 16, \
 	__builtin_choose_expr(sizeof(a) == 1, 2, \
 	__builtin_choose_expr(sizeof(a) == 2, 4, \
-	(0)  )))))))))))))))))))
+	(0)  ))))))))))))))))))))
 
 /* Disable Clang's warning of "cont" unused variable. */
 #if defined (__clang__)

--- a/print.h
+++ b/print.h
@@ -171,6 +171,11 @@ void __print_func (FILE *fd, int count, unsigned short types[], ...) {
 	__builtin_choose_expr(sizeof(a) == 2, 4, \
 	(0)  )))))))))))))))))))
 
+/* Disable Clang's warning of "cont" unused variable. */
+#if defined (__clang__)
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+
 #define __print_push(c,size,cont) (cont, *--_p = c | (size << 5))
 #define __builtin_choose_expr __builtin_choose_expr
 #define __print_is_type(a, t) __builtin_types_compatible_p(typeof(a), t)

--- a/print.h
+++ b/print.h
@@ -1,9 +1,12 @@
+#ifndef PRINT_H
+#define PRINT_H
+
 #include <stdarg.h>
 #include <stdio.h>
 
-int __print_enable_color = 1;
+static int __print_enable_color = 1;
 
-void __print_color(FILE* fd, int a) {
+static void __print_color(FILE* fd, int a) {
 	if (!__print_enable_color) return;
 	if (a == -1) fputs("\x1b(B\x1b[m", fd);
 	else fprintf(fd, "\x1b[38;5;%im", a);
@@ -24,13 +27,13 @@ void __print_color(FILE* fd, int a) {
 	if (n > max_len) fputs("...", fd);	 \
 	fputc(']', fd);
 
-int __print_color_normal = -1; // -1 means default terminal foreground color
-int __print_color_number = 4;
-int __print_color_string = 1;
-int __print_color_hex = 2;
-int __print_color_float = 5;
+static int __print_color_normal = -1; // -1 means default terminal foreground color
+static int __print_color_number = 4;
+static int __print_color_string = 1;
+static int __print_color_hex = 2;
+static int __print_color_float = 5;
 
-void __print_setup_colors(int normal, int number, int string, int hex, int fractional) {
+static void __print_setup_colors(int normal, int number, int string, int hex, int fractional) {
 	__print_color_string = string;
 	__print_color_number = number;
 	__print_color_hex = hex;
@@ -38,7 +41,7 @@ void __print_setup_colors(int normal, int number, int string, int hex, int fract
 	__print_color_float = fractional;
 }
 
-void __print_func (FILE *fd, int count, unsigned short types[], ...) {
+static void __print_func (FILE *fd, int count, unsigned short types[], ...) {
 	va_list v;
 	va_start(v, types);
 	#ifdef __print_DEBUG
@@ -197,3 +200,4 @@ void __print_func (FILE *fd, int count, unsigned short types[], ...) {
 
 #define print(a...) fprint(stdout, a)
 
+#endif


### PR DESCRIPTION
Commit messages:

[print.h: replace else..if with switch..case and use fput* functions](https://github.com/exebook/generic-print/commit/c4e2f4ec743e96949deffdccbae349d9e32d43dc)

\* Replace all else..if branches with switch..case. A optimizing
compiler might be able to create a lookup table instead relying
on the branches.

\* Replace fprintf() with fputc() and fputs(), for strings that
do not require formatting. C compilers such as TCC (that doesn't
replace fprintf() calls, for (non-formatting) strings with fput*
functions) can make use of this. This shall increase the performance
a bit or so when compiled with TCC.

[print.h: disable clang "unused variable" warning](https://github.com/exebook/generic-print/commit/068989be7e218fe3af419bc98ad356644dab2532)

[Makefile: add uninstall and clean sections](https://github.com/exebook/generic-print/commit/bb3f0cd45e007eead40845664b194a41d67080d3)

\* It's useful to have an uninstall section, so when a user need
to uninstall these files, they don't have to track them down,
where they might have been installed.

\* Adding clean as well, for the demo.
